### PR TITLE
fix(ci): discard local changes before branch checkout in tagpr

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 22
       - run: npm ci
       - run: npm install simple-git
+      - name: Discard local changes before checkout
+        run: git checkout -- .
       - name: Trigger CI Workflow
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary

Fix git checkout error in tagpr workflow caused by uncommitted changes.

## Problem

The tagpr workflow fails with the following error when trying to checkout the PR branch:
- `npm ci` and `npm install simple-git` modify `package.json` and `package-lock.json`
- These uncommitted changes cause `git checkout` to fail

## Solution

Add a step to discard local changes (`git checkout -- .`) before switching branches.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
